### PR TITLE
Update BeanstalkController.php

### DIFF
--- a/src/udokmeci/yii2beanstalk/BeanstalkController.php
+++ b/src/udokmeci/yii2beanstalk/BeanstalkController.php
@@ -77,11 +77,12 @@ class BeanstalkController extends Controller {
 
 	public function decayJob($job){
 		$jobStats = Yii::$app->beanstalk->statsJob($job);
-		if ($jobStats->delay >= static::DELAY_MAX) {
+		$delay_job = $jobStats->delay - $jobStats->age;
+		if ($delay_job >= static::DELAY_MAX) {
 			Yii::$app->beanstalk->delete($job);
 			fwrite(STDERR, Console::ansiFormat(Yii::t('udokmeci.beanstalkd', 'Decaying Job Deleted!') . "\n", [Console::FG_RED]));
 		} else {
-			Yii::$app->beanstalk->release($job, static::DELAY_PIRORITY, static::DELAY_TIME^($jobStats->delay + 1));
+			Yii::$app->beanstalk->release($job, static::DELAY_PIRORITY, $jobStats->delay + self::DELAY_TIME);
 		}
 	}
 


### PR DESCRIPTION
Так как при выполнении задач с задержкой или большой очередью,  $jobStats->delay всегда больше static::DELAY_MAX