### PR TITLE
Delayscheme handling

### DIFF
--- a/src/udokmeci/yii2beanstalk/BeanstalkController.php
+++ b/src/udokmeci/yii2beanstalk/BeanstalkController.php
@@ -138,7 +138,7 @@ class BeanstalkController extends Controller
     {
         $jobStats = Yii::$app->beanstalk->statsJob($job);
 
-        if ( $jobStats->releases == static::$DELAY_RETRIES) {
+        if ( $jobStats->releases == static::DELAY_RETRIES) {
             Yii::$app->beanstalk->delete($job);
             fwrite(STDERR, Console::ansiFormat(Yii::t('udokmeci.beanstalkd', 'Retrying Job Deleted on retry '.$jobStats->releases.'!') . "\n", [Console::FG_RED]));
         } else {


### PR DESCRIPTION
This enhancement adds a retry option with exponential back off to a failed job that can be retried. Exponential back off follow a common pattern for retrying jobs (see https://developers.google.com/drive/v2/web/handle-errors). A new constant DELAY_EXPONENTIAL has added to signal this handling. DELAY_RETRIES specifies the maximum amount of retries for DELAY_EXPONENTIAL.
For clarity job execution and handling has been refactored into a new function.