### PR TITLE
returning self::BURY should bury

### DIFF
--- a/src/udokmeci/yii2beanstalk/BeanstalkController.php
+++ b/src/udokmeci/yii2beanstalk/BeanstalkController.php
@@ -321,7 +321,7 @@ class BeanstalkController extends Controller
                 Yii::$app->beanstalk->release($job);
                 break;
             case self::BURY:
-                Yii::$app->beanstalk->delete($job);
+                Yii::$app->beanstalk->bury($job);
                 break;
             case self::DECAY:
                 $this->decayJob($job);


### PR DESCRIPTION
Returning self::BURY doesn't bury a job, but deletes it. The reason is quite obvious.