### PR TITLE
Manage idle CPU load

### DIFF
--- a/src/udokmeci/yii2beanstalk/BeanstalkController.php
+++ b/src/udokmeci/yii2beanstalk/BeanstalkController.php
@@ -317,6 +317,9 @@ class BeanstalkController extends Controller
 
                             $job = $bean->reserve(0);
                             if (!$job) {
+                                if ($this->beanstalk->sleep) {
+                                    usleep($this->beanstalk->sleep);
+                                }                                
                                 continue;
                             }
 


### PR DESCRIPTION
Add the sleep also when no job was found to manage CPU load of the worker process.